### PR TITLE
Provide a libctl3 symlink for the mpb package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debathena-thirdparty (1.2.3) unstable; urgency=low
+
+  * Bump guile to 2.0 which is in precise and trusty
+
+ -- Jonathan Reed <jdreed@mit.edu>  Wed, 28 May 2014 09:45:36 -0400
+
 debathena-thirdparty (1.2.2) unstable; urgency=low
 
   * Provide a symlink /usr/share/libctl3 pointing at /usr/share/libctl,

--- a/lists/common
+++ b/lists/common
@@ -199,9 +199,9 @@ liblog4net1.2-cil
 dx
 dx-doc
 dxsamples
-guile-1.8
-guile-1.8-doc
-guile-1.8-dev
+guile-2.0
+guile-2.0-doc
+guile-2.0-dev
 guile-cairo
 libgl1-mesa-dev
 libboost-dev


### PR DESCRIPTION
Per alexp, the mpb package is looking in /usr/share/libctl3, but
the "libctl3" package installs things in /usr/share/libctl.  This
creates the necessary symlink.  It should be removed once the upstream
package is fixed
