### PR TITLE
Bump guile-dev to 2.0 for trusty

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debathena-thirdparty (1.2.3) unstable; urgency=low
+
+  * Bump guile-dev to 2.0 for Trusty
+
+ -- Jonathan Reed <jdreed@mit.edu>  Wed, 28 May 2014 11:55:21 -0400
+
 debathena-thirdparty (1.2.2) unstable; urgency=low
 
   * Provide a symlink /usr/share/libctl3 pointing at /usr/share/libctl,

--- a/lists/trusty
+++ b/lists/trusty
@@ -1,0 +1,2 @@
+-guile-1.8-dev
+guile-2.0-dev


### PR DESCRIPTION
We can probably actually do this unconditonally, since guile 2.0
is in both trusty and precise, but I don't want to break things
out from under people.
