### PR TITLE
Drop maxima-emacs on Precise

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debathena-thirdparty (1.2.4) unstable; urgency=low
+
+  * Drop maxima-emacs on Precise, because of dependency resolution issues
+
+ -- Jonathan Reed <jdreed@mit.edu>  Fri, 30 May 2014 15:09:43 -0400
+
 debathena-thirdparty (1.2.3) unstable; urgency=low
 
   * Bump guile-dev to 2.0 for Trusty

--- a/lists/precise
+++ b/lists/precise
@@ -1,2 +1,3 @@
 +openfoam222
 +paraviewopenfoam3120
+-maxima-emacs


### PR DESCRIPTION
It apparently confuses apt-get's dependency resolver enough
to prevent thirdparty from being installed.
